### PR TITLE
add function to generate a free port in the range

### DIFF
--- a/brokerconfig/assets/test_config.yml
+++ b/brokerconfig/assets/test_config.yml
@@ -12,6 +12,8 @@ redis:
   process_check_interval: 5
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   backup:
     endpoint_url: http://s3url.com
     bucket_name: redis-backups

--- a/brokerconfig/assets/test_config.yml-backup-minimum
+++ b/brokerconfig/assets/test_config.yml-backup-minimum
@@ -11,6 +11,8 @@ redis:
   process_check_interval: 5
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   backup:
     endpoint_url: http://s3url.com
     bucket_name: redis-backups

--- a/brokerconfig/assets/test_config.yml-invalid
+++ b/brokerconfig/assets/test_config.yml-invalid
@@ -6,6 +6,8 @@ redis:
   redis_conf_path: /path/to/redis/config.conf
   process_check_interval: 5
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   backup:
     endpoint_url: http://s3url.com
     bucket_name: redis-backups

--- a/brokerconfig/assets/test_config.yml-no-backup
+++ b/brokerconfig/assets/test_config.yml-no-backup
@@ -11,6 +11,8 @@ redis:
   process_check_interval: 5
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
       - 10.0.0.1

--- a/brokerconfig/config.go
+++ b/brokerconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/cloudfoundry-incubator/candiedyaml"
+	"github.com/pivotal-cf/cf-redis-broker/system"
 )
 
 type Config struct {
@@ -95,9 +96,28 @@ func ValidateConfig(config ServiceConfiguration) error {
 		return err
 	}
 
+	err = checkPortRange(config.SharedMinPort, config.SharedMaxPort)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
-
+func checkPortRange(sharedMinPort, sharedMaxPort int) error {
+	if sharedMinPort > sharedMaxPort {
+		return errors.New("Not valid range port: minimum port is higher than maximum port")
+	}
+	if sharedMinPort < system.MIN_ACCEPTED_PORT {
+		return errors.New(fmt.Sprintf("Not valid range port: minimum port is lower than %d", system.MIN_ACCEPTED_PORT))
+	}
+	if sharedMinPort > system.MAX_ACCEPTED_PORT {
+		return errors.New(fmt.Sprintf("Not valid range port: minimum port is higher than %d", system.MAX_ACCEPTED_PORT))
+	}
+	if sharedMaxPort > system.MAX_ACCEPTED_PORT {
+		return errors.New(fmt.Sprintf("Not valid range port: maximum port is higher than %d", system.MAX_ACCEPTED_PORT))
+	}
+	return nil
+}
 func checkPathExists(path string, description string) error {
 	_, err := os.Stat(path)
 	if err != nil {

--- a/brokerconfig/config.go
+++ b/brokerconfig/config.go
@@ -45,6 +45,10 @@ type ServiceConfiguration struct {
 	SupportURL                  string    `yaml:"support_url"`
 	DisplayName                 string    `yaml:"display_name"`
 	IconImage                   string    `yaml:"icon_image"`
+        SharedMaxPort               int       `yaml:"shared_max_port"`
+        SharedMinPort               int       `yaml:"shared_min_port"`
+
+
 }
 
 type Dedicated struct {

--- a/brokerintegration/assets/broker.yml
+++ b/brokerintegration/assets/broker.yml
@@ -15,6 +15,8 @@ redis:
   support_url: http://support.pivotal.io
   display_name: Redis
   description: Redis service to provide a key-value store
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-colocated
+++ b/brokerintegration/assets/broker.yml-colocated
@@ -15,6 +15,8 @@ redis:
   support_url: http://support.pivotal.io
   display_name: Redis
   description: Redis service to provide a key-value store
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-consistency
+++ b/brokerintegration/assets/broker.yml-consistency
@@ -15,6 +15,8 @@ redis:
   support_url: http://support.pivotal.io
   display_name: Redis
   description: Redis service to provide a key-value store
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.127.0.0.1.xip.io

--- a/brokerintegration/assets/broker.yml-extra-node
+++ b/brokerintegration/assets/broker.yml-extra-node
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 3
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes":
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-no-dedicated
+++ b/brokerintegration/assets/broker.yml-no-dedicated
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 3
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes": []
     "statefile_path": "/tmp/redis-config-dir/statefile.json"

--- a/brokerintegration/assets/broker.yml-no-shared
+++ b/brokerintegration/assets/broker.yml-no-shared
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 0
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes":
     - server1.lvh.me

--- a/brokerintegration/assets/broker.yml-one-dedicated
+++ b/brokerintegration/assets/broker.yml-one-dedicated
@@ -9,6 +9,8 @@
   pidfile_directory: /tmp/pidfiles
   "log_directory": "/tmp/redis-log-dir"
   "service_instance_limit": 3
+  "shared_max_port": 65535
+  "shared_min_port": 1024
   "dedicated":
     "nodes":
     - "127.0.0.1"

--- a/brokerintegration/assets/broker.yml.updated_maxmemory
+++ b/brokerintegration/assets/broker.yml.updated_maxmemory
@@ -10,6 +10,8 @@ redis:
   process_check_interval: 1
   start_redis_timeout: 3
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes: []
     statefile_path: /tmp/redis-config-dir/statefile.json

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	localCreator := &redis.LocalInstanceCreator{
-		FindFreePort:            system.FindFreePort,
+		FindFreeInRangePort:            system.FindFreeInRangePort,
 		RedisConfiguration:      config.RedisConfiguration,
 		ProcessController:       processController,
 		LocalInstanceRepository: localRepo,

--- a/cmd/broker/main.go
+++ b/cmd/broker/main.go
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	localCreator := &redis.LocalInstanceCreator{
-		FindFreeInRangePort:            system.FindFreeInRangePort,
+		FreeTcpPort:     system.NewFreeTcpPort(),
 		RedisConfiguration:      config.RedisConfiguration,
 		ProcessController:       processController,
 		LocalInstanceRepository: localRepo,

--- a/configmigratorintegration/assets/broker.yml
+++ b/configmigratorintegration/assets/broker.yml
@@ -10,6 +10,8 @@ redis:
   data_directory: /tmp/redis-data-dir
   log_directory: /tmp/redis-log-dir
   service_instance_limit: 3
+  shared_max_port: 65535
+  shared_min_port: 1024
   dedicated:
     nodes:
     - server1.lvh.me

--- a/redis/local_instance_creator.go
+++ b/redis/local_instance_creator.go
@@ -31,7 +31,6 @@ type LocalInstanceRepository interface {
 
 type LocalInstanceCreator struct {
 	LocalInstanceRepository
-	FindFreePort       func(int) (int, error)
 	ProcessController  ProcessController
 	RedisConfiguration brokerconfig.ServiceConfiguration
         FindFreeInRangePort  func(int, int) (int, error)
@@ -48,7 +47,7 @@ func (localInstanceCreator *LocalInstanceCreator) Create(instanceID string) erro
 	}
 	SharedMaxPort := localInstanceCreator.RedisConfiguration.SharedMaxPort
         SharedMinPort := localInstanceCreator.RedisConfiguration.SharedMinPort
-        port, err := localInstanceCreator.FindFreeInRangePort(SharedMaxPort, SharedMinPort)
+        port, err := localInstanceCreator.FindFreeInRangePort(SharedMinPort, SharedMaxPort)
         if err != nil {
                 return err
         }

--- a/redis/local_instance_creator.go
+++ b/redis/local_instance_creator.go
@@ -59,7 +59,7 @@ func (localInstanceCreator *LocalInstanceCreator) Create(instanceID string) erro
 		Password: uuid.NewRandom().String(),
 	}
 
-	err := localInstanceCreator.Setup(instance)
+	err = localInstanceCreator.Setup(instance)
 	if err != nil {
 		return err
 	}

--- a/redis/local_instance_creator_test.go
+++ b/redis/local_instance_creator_test.go
@@ -12,15 +12,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/cf-redis-broker/system"
 )
 
 var freePortsFound int
-
-func fakeFindFreeInRangePortfinder(min ,max int) (int, error) {
-
-	freePortsFound++
-	return 8080, nil
-}
 
 var _ = Describe("Local Redis Creator", func() {
 
@@ -31,12 +26,15 @@ var _ = Describe("Local Redis Creator", func() {
 
 	BeforeEach(func() {
 		instanceID = uuid.NewRandom().String()
+		freeTcpPort := &system.FakeFreeTcpPort{Cb: func() {
+			freePortsFound++
+		}}
 		fakeProcessController = &fakes.FakeProcessController{}
 
 		fakeLocalRepository = new(fakes.FakeLocalRepository)
 
 		localInstanceCreator = &redis.LocalInstanceCreator{
-			FindFreeInRangePort:     fakeFindFreeInRangePortfinder,
+			FreeTcpPort:     freeTcpPort,
 			ProcessController:       fakeProcessController,
 			LocalInstanceRepository: fakeLocalRepository,
 			RedisConfiguration: brokerconfig.ServiceConfiguration{

--- a/redis/local_instance_creator_test.go
+++ b/redis/local_instance_creator_test.go
@@ -16,7 +16,8 @@ import (
 
 var freePortsFound int
 
-func fakeFreePortFinder() (int, error) {
+func fakeFindFreeInRangePortfinder(int, int) (int, error) {
+
 	freePortsFound++
 	return 8080, nil
 }
@@ -35,7 +36,7 @@ var _ = Describe("Local Redis Creator", func() {
 		fakeLocalRepository = new(fakes.FakeLocalRepository)
 
 		localInstanceCreator = &redis.LocalInstanceCreator{
-			FindFreePort:            fakeFreePortFinder,
+			FindFreePort:            fakeFindFreeInRangePortfinder,
 			ProcessController:       fakeProcessController,
 			LocalInstanceRepository: fakeLocalRepository,
 			RedisConfiguration: brokerconfig.ServiceConfiguration{

--- a/redis/local_instance_creator_test.go
+++ b/redis/local_instance_creator_test.go
@@ -16,7 +16,7 @@ import (
 
 var freePortsFound int
 
-func fakeFindFreeInRangePortfinder(int, int) (int, error) {
+func fakeFindFreeInRangePortfinder(min ,max int) (int, error) {
 
 	freePortsFound++
 	return 8080, nil
@@ -36,7 +36,7 @@ var _ = Describe("Local Redis Creator", func() {
 		fakeLocalRepository = new(fakes.FakeLocalRepository)
 
 		localInstanceCreator = &redis.LocalInstanceCreator{
-			FindFreePort:            fakeFindFreeInRangePortfinder,
+			FindFreeInRangePort:     fakeFindFreeInRangePortfinder,
 			ProcessController:       fakeProcessController,
 			LocalInstanceRepository: fakeLocalRepository,
 			RedisConfiguration: brokerconfig.ServiceConfiguration{

--- a/system/fake_free_tcp_port.go
+++ b/system/fake_free_tcp_port.go
@@ -1,0 +1,11 @@
+package system
+
+type FakeFreeTcpPort struct {
+	FreeTcpPort
+	Cb func()
+}
+
+func (f *FakeFreeTcpPort) FindFreePortInRange(minport int, maxport int) (int, error) {
+	f.Cb()
+	return 8080, nil
+}

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -1,18 +1,33 @@
 package system
 
 import (
-	"net"
-	"strconv"
+        "net"
+        "strconv"
+        "errors"
 )
 
-func FindFreePort() (int, error) {
-	l, _ := net.Listen("tcp", ":0")
-	defer l.Close()
+func FindFreePort(num int) (int, error) {
+        t := strconv.Itoa(num)
+        toto := ":" + t
+        l, err := net.Listen("tcp", toto)
+        if err != nil {
+                return -1, err
+        }
+        parsedPort, _ := strconv.ParseInt(l.Addr().String()[5:], 10, 32)
+        return int(parsedPort), nil
+}
 
-	parsedPort, parseErr := strconv.ParseInt(l.Addr().String()[5:], 10, 32)
-	if parseErr != nil {
-		return -1, parseErr
-	}
 
-	return int(parsedPort), nil
+func FindFreeInRangePort(Maxport int, Minport int)(int,error) {
+        i := Minport
+        port, err :=FindFreePort(i)
+        for (err != nil) && (i<Maxport) {
+        i=i+1
+        port, err =FindFreePort(i)
+        }
+
+        if (err != nil) {
+        return -1, errors.New("Sorry No Free port in this range  is availble")
+        }
+        return port, err
 }

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -31,15 +31,6 @@ func isPortAvailable(num int) bool {
 	return true
 }
 func (f FreeRangeTcpPort) FindFreePortInRange(minport int, maxport int) (int, error) {
-	if minport > maxport {
-		return -1, errors.New("Not valid range port: minimum port is higher than maximum port")
-	}
-	if minport < MIN_ACCEPTED_PORT {
-		return -1, errors.New("Not valid range port: minimum port is lower than " + strconv.Itoa(MIN_ACCEPTED_PORT))
-	}
-	if maxport > MAX_ACCEPTED_PORT {
-		return -1, errors.New("Not valid range port: maximum port is higher than " + strconv.Itoa(MIN_ACCEPTED_PORT))
-	}
 	port := minport
 	for port <= maxport {
 		if f.IsPortAvailable(port) {

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -8,8 +8,8 @@ import (
 
 func FindFreePort(num int) (int, error) {
         t := strconv.Itoa(num)
-        toto := ":" + t
-        l, err := net.Listen("tcp", toto)
+        a := ":" + t
+        l, err := net.Listen("tcp",a)
         if err != nil {
                 return -1, err
         }
@@ -27,7 +27,7 @@ func FindFreeInRangePort(Maxport int, Minport int)(int,error) {
         }
 
         if (err != nil) {
-        return -1, errors.New("Sorry No Free port in this range  is availble")
+        return -1, errors.New("Sorry No Free port in this range is available")
         }
         return port, err
 }

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -30,7 +30,6 @@ func isPortAvailable(num int) bool {
 	l.Close()
 	return true
 }
-
 func (f FreeRangeTcpPort) FindFreePortInRange(minport int, maxport int) (int, error) {
 	if minport > maxport {
 		return -1, errors.New("Not valid range port: minimum port is higher than maximum port")
@@ -42,11 +41,11 @@ func (f FreeRangeTcpPort) FindFreePortInRange(minport int, maxport int) (int, er
 		return -1, errors.New("Not valid range port: maximum port is higher than " + strconv.Itoa(MIN_ACCEPTED_PORT))
 	}
 	port := minport
-	for port < maxport {
+	for port <= maxport {
 		if f.IsPortAvailable(port) {
 			return port, nil
 		}
 		port++
 	}
-	return -1, errors.New("Sorry no port is available in this range")
+	return -1, errors.New("No port is available in the range. Please ask help to your Operator")
 }

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -18,14 +18,16 @@ func FindFreePort(num int) (int, error) {
 }
 
 
-func FindFreeInRangePort(Maxport int, Minport int)(int,error) {
+func FindFreeInRangePort(Minport int, Maxport int)(int,error) {
+	if(Minport > Maxport) || (Minport < 1024) || (Maxport > 65535){ 
+        return -1, errors.New("Sorry No Free port in this range is available")
+        }
         i := Minport
         port, err :=FindFreePort(i)
         for (err != nil) && (i<Maxport) {
         i=i+1
         port, err =FindFreePort(i)
         }
-
         if (err != nil) {
         return -1, errors.New("Sorry No Free port in this range is available")
         }

--- a/system/free_tcp_port.go
+++ b/system/free_tcp_port.go
@@ -1,35 +1,52 @@
 package system
 
 import (
-        "net"
-        "strconv"
-        "errors"
+	"net"
+	"strconv"
+	"errors"
 )
 
-func FindFreePort(num int) (int, error) {
-        t := strconv.Itoa(num)
-        a := ":" + t
-        l, err := net.Listen("tcp",a)
-        if err != nil {
-                return -1, err
-        }
-        parsedPort, _ := strconv.ParseInt(l.Addr().String()[5:], 10, 32)
-        return int(parsedPort), nil
+const (
+	MIN_ACCEPTED_PORT int = 1024
+	MAX_ACCEPTED_PORT int = 65535
+)
+
+type FreeTcpPort interface {
+	FindFreePortInRange(minport int, maxport int) (int, error)
+}
+type FreeRangeTcpPort struct {
+	FreeTcpPort
+	IsPortAvailable func(num int) bool
 }
 
+func NewFreeTcpPort() FreeTcpPort {
+	return &FreeRangeTcpPort{IsPortAvailable: isPortAvailable}
+}
+func isPortAvailable(num int) bool {
+	l, err := net.Listen("tcp", ":" + strconv.Itoa(num))
+	if err != nil {
+		return false
+	}
+	l.Close()
+	return true
+}
 
-func FindFreeInRangePort(Minport int, Maxport int)(int,error) {
-	if(Minport > Maxport) || (Minport < 1024) || (Maxport > 65535){ 
-        return -1, errors.New("Sorry No Free port in this range is available")
-        }
-        i := Minport
-        port, err :=FindFreePort(i)
-        for (err != nil) && (i<Maxport) {
-        i=i+1
-        port, err =FindFreePort(i)
-        }
-        if (err != nil) {
-        return -1, errors.New("Sorry No Free port in this range is available")
-        }
-        return port, err
+func (f FreeRangeTcpPort) FindFreePortInRange(minport int, maxport int) (int, error) {
+	if minport > maxport {
+		return -1, errors.New("Not valid range port: minimum port is higher than maximum port")
+	}
+	if minport < MIN_ACCEPTED_PORT {
+		return -1, errors.New("Not valid range port: minimum port is lower than " + strconv.Itoa(MIN_ACCEPTED_PORT))
+	}
+	if maxport > MAX_ACCEPTED_PORT {
+		return -1, errors.New("Not valid range port: maximum port is higher than " + strconv.Itoa(MIN_ACCEPTED_PORT))
+	}
+	port := minport
+	for port < maxport {
+		if f.IsPortAvailable(port) {
+			return port, nil
+		}
+		port++
+	}
+	return -1, errors.New("Sorry no port is available in this range")
 }

--- a/system/free_tcp_port_test.go
+++ b/system/free_tcp_port_test.go
@@ -21,6 +21,18 @@ var _ = Describe("Find next available TCP port in a range", func() {
 			Expect(port).To(BeNumerically(">=", 40000))
 			Expect(port).To(BeNumerically("<=", 40005))
 		})
+		It("should give the only free port if the the minimum port is equals to maximum port", func() {
+			freeTcpPort = NewFreeTcpPort()
+			freeTcpPort.(*FreeRangeTcpPort).IsPortAvailable = func(num int) bool {
+				return true
+			}
+
+			port, err := freeTcpPort.FindFreePortInRange(65000, 65000)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(port).To(BeEquivalentTo(65000))
+		})
 	})
 	Context("with an invalid range port", func() {
 		It("should return an error if minimum port is greater than maximum port", func() {
@@ -49,7 +61,7 @@ var _ = Describe("Find next available TCP port in a range", func() {
 		It("Should return an error", func() {
 			_, err := freeTcpPort.FindFreePortInRange(40000, 40005)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("no port is available in this range"))
+			Expect(err.Error()).To(ContainSubstring("No port is available in the range"))
 		})
 	})
 

--- a/system/free_tcp_port_test.go
+++ b/system/free_tcp_port_test.go
@@ -1,28 +1,29 @@
 package system_test
 
 import (
-	"net"
-	"regexp"
-	"strconv"
+        "net"
+        "regexp"
+        "strconv"
 
-	"github.com/pivotal-cf/cf-redis-broker/system"
+        "github.com/pivotal-cf/cf-redis-broker/system"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+        . "github.com/onsi/ginkgo"
+        . "github.com/onsi/gomega"
 )
 
 var _ = Describe("Next available TCP port", func() {
 
-	It("finds a free TCP port", func() {
-		port, _ := system.FindFreePort()
-		portStr := strconv.Itoa(port)
+        It("finds a the  free TCP port in the range ", func() {
+                port, _ := system.FindFreeInRangePort(40005,40000)
+                portStr := strconv.Itoa(port)
 
-		matched, err := regexp.MatchString("^[0-9]+$", portStr)
-		Ω(matched).To(Equal(true))
+                matched, err := regexp.MatchString("^[0-9]+$", portStr)
+                Ω(matched).To(Equal(true))
 
-		l, err := net.Listen("tcp", ":"+portStr)
-		Ω(err).ToNot(HaveOccurred())
-		l.Close()
-	})
+                l, err := net.Listen("tcp", ":"+portStr)
+                Ω(err).ToNot(HaveOccurred())
+                l.Close()
+        })
 
 })
+

--- a/system/free_tcp_port_test.go
+++ b/system/free_tcp_port_test.go
@@ -34,23 +34,6 @@ var _ = Describe("Find next available TCP port in a range", func() {
 			Expect(port).To(BeEquivalentTo(65000))
 		})
 	})
-	Context("with an invalid range port", func() {
-		It("should return an error if minimum port is greater than maximum port", func() {
-			_, err := freeTcpPort.FindFreePortInRange(6000, 5000)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("minimum port is higher than maximum port"))
-		})
-		It("should return an error if minimum port is lower than accepted minimum port", func() {
-			_, err := freeTcpPort.FindFreePortInRange(MIN_ACCEPTED_PORT - 1, 5000)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("minimum port is lower than"))
-		})
-		It("should return an error if maximum port is lower than accepted maximum port", func() {
-			_, err := freeTcpPort.FindFreePortInRange(4000, MAX_ACCEPTED_PORT + 1)
-			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("maximum port is higher than"))
-		})
-	})
 	Context("When no port is available in range", func() {
 		BeforeEach(func() {
 			freeTcpPort = NewFreeTcpPort()

--- a/system/free_tcp_port_test.go
+++ b/system/free_tcp_port_test.go
@@ -24,6 +24,11 @@ var _ = Describe("Next available TCP port", func() {
                 Ω(err).ToNot(HaveOccurred())
                 l.Close()
         })
+        It("test the case when no port available in the range ", func() {
+                _, err := system.FindFreeInRangePort(-1,-1)
+                Ω(err).To(HaveOccurred())
+                Ω(err).err.String()).Should(ContainSubstring("No Free port"))                
+        })
 
 })
 

--- a/system/free_tcp_port_test.go
+++ b/system/free_tcp_port_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Next available TCP port", func() {
         It("test the case when no port available in the range ", func() {
                 _, err := system.FindFreeInRangePort(-1,-1)
                 Ω(err).To(HaveOccurred())
-                Ω(err).err.String()).Should(ContainSubstring("No Free port"))                
+                Ω(err).err.String().Should(ContainSubstring("No Free port"))                
         })
 
 })


### PR DESCRIPTION
As documented in https://github.com/pivotal-cf/cf-redis-release/issues/36, this PR enables control the shared instance port used within a preferred range.

- during configuration loading if ports are misconfigured it will report directly report the error. 
- When the service broker try to find a free port during provisioning and no port is available in the range it will give a service broker error. This error will ask to the user to contact his operator.

Regarding unit tests and integrations run as part of this PR: 
- integration tests were run with the docker image provided. I get some errors in this usecase, when a test want to check that program failed when a directory is not writeable it doesn't failed because on docker user privileged are root and this user is permitted to write on a folder which is not. Example: https://github.com/orange-cloudfoundry/cf-redis-broker/blob/shared-instance-ports-broker-prepation/brokerintegration/development_instance_provisioning_test.go#L127-L138
- all other tests look good. 